### PR TITLE
fix: restore selectedCategory when closing video player

### DIFF
--- a/Nebulo_AVPlayer/Nebulo/Nebulo/Views/Main/MainView.swift
+++ b/Nebulo_AVPlayer/Nebulo/Nebulo/Views/Main/MainView.swift
@@ -214,6 +214,7 @@ extension MainView {
                 if selectedChannel?.id == channel.id { 
                     withAnimation(.easeInOut(duration: 0.4)) { 
                         selectedChannel = nil
+                        selectedCategory = viewModel.lastSourceCategory
                         showQuickSwitcher = false 
                     }
                     

--- a/Nebulo_Original/Nebulo_V2.3/Views/Main/MainView.swift
+++ b/Nebulo_Original/Nebulo_V2.3/Views/Main/MainView.swift
@@ -214,6 +214,7 @@ extension MainView {
                 if selectedChannel?.id == channel.id { 
                     withAnimation(.easeInOut(duration: 0.4)) { 
                         selectedChannel = nil
+                        selectedCategory = viewModel.lastSourceCategory
                         showQuickSwitcher = false 
                     }
                     


### PR DESCRIPTION
When the fullscreen player is dismissed, selectedCategory was not restored from lastSourceCategory, causing the app to jump back to the home/dashboard screen instead of returning to the channel list.

Fixes mongoosemonke504/NebuloIPTV#9